### PR TITLE
added null checks to prevent errors, e.g. issue #18 in reference-beacon

### DIFF
--- a/src/main/java/bio/knowledge/ontology/mapping/umls/UMLSBiolinkMapping.java
+++ b/src/main/java/bio/knowledge/ontology/mapping/umls/UMLSBiolinkMapping.java
@@ -9,6 +9,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import bio.knowledge.ontology.BiolinkClass;
 import bio.knowledge.ontology.BiolinkTerm;
 import bio.knowledge.ontology.mapping.BiolinkModelMapping;
@@ -21,6 +24,7 @@ import bio.knowledge.ontology.mapping.NameSpace;
 public class UMLSBiolinkMapping extends BiolinkModelMapping {
 
 	private static final long serialVersionUID = 373558122178877621L;
+	private static Logger _logger = LoggerFactory.getLogger(UMLSBiolinkMapping.class);
 	
 	public UMLSBiolinkMapping() {
 		
@@ -71,8 +75,12 @@ public class UMLSBiolinkMapping extends BiolinkModelMapping {
 		
 		for (String name : biolinkClasses) {
 			BiolinkClass c = classModelLookup.getClassByName(name);
-			classes.add(c);
-			classes.addAll(classInheritanceLookup.getDescendants(c));
+			if (c != null) {
+				classes.add(c);
+				classes.addAll(classInheritanceLookup.getDescendants(c));
+			} else {
+				_logger.info(name + " does not appear to be a BiolinkClass");
+			}
 		}
 		
 		biolinkClasses = classes.stream().map(c -> c.getName()).collect(Collectors.toList());
@@ -98,9 +106,11 @@ public class UMLSBiolinkMapping extends BiolinkModelMapping {
 	private String biolinkToUmls(String biolinkClassName) {
 		BiolinkClass biolinkClass = classModelLookup.getClassByName(biolinkClassName);
 		
-		for (String curie : biolinkClass.getMappings()) {
-			if (curie.startsWith(NameSpace.UMLSSG.getPrefix())) {
-				return curie;
+		if (biolinkClass != null) {
+			for (String curie : biolinkClass.getMappings()) {
+				if (curie.startsWith(NameSpace.UMLSSG.getPrefix())) {
+					return curie;
+				}
 			}
 		}
 		


### PR DESCRIPTION
I noticed _issue #18: Filtering on non-Biolink categories gives internal service error_ , in the reference-beacon (https://github.com/NCATS-Tangerine/reference-beacon/issues/18) could be traced to errors being thrown while in the ontology module. Changes proposed here fix the issue to the reference beacon